### PR TITLE
Us 04/feat/add poem page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.4.1"
+    "react-router": "^7.4.1",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@types/react": "^19.0.12",

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -15,7 +15,7 @@ function Header() {
               <Link to="/">Poèmes</Link>
             </li>
             <li>
-              <Link to="/">Ajouter</Link>
+              <Link to="/add-poem">Ajouter</Link>
             </li>
             <li>
               <Link to="/">Modifier</Link>

--- a/client/src/pages/AddPoemPage/AddPoemPage.css
+++ b/client/src/pages/AddPoemPage/AddPoemPage.css
@@ -1,0 +1,65 @@
+.add-poem-page-main {
+  margin: 0 8px;
+  text-align: center;
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    input {
+      margin: 0 auto;
+      width: 100%;
+      padding: 12px 0;
+      background: #f5f8fa;
+      border: 1px solid #bbbbbb;
+      border-radius: 8px;
+    }
+    textarea {
+      width: 100%;
+      margin: 0 auto;
+      background: #f5f8fa;
+      border: 1px solid #bbbbbb;
+      border-radius: 8px;
+    }
+    #image-poem {
+      display: none;
+    }
+    .file-label {
+      /* display: inline-block; */
+      padding: 10px 24px;
+      background: #4caf50;
+      color: #fff;
+      border-radius: 8px;
+      cursor: pointer;
+      margin: 0 auto;
+      transition: background 0.2s;
+      &:hover {
+        background: #388e3c;
+      }
+    }
+
+    button {
+      margin: 0 auto;
+      padding: 8px 56px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      background: #d9d9d9;
+      transition: background 0.4s;
+      &:hover {
+        background-color: #888888;
+      }
+    }
+  }
+  @media screen and (min-width: 768px) {
+    form {
+      textarea {
+        width: 80%;
+        max-width: 800px;
+      }
+      input {
+        width: 80%;
+        max-width: 800px;
+      }
+    }
+  }
+}

--- a/client/src/pages/AddPoemPage/AddPoemPage.tsx
+++ b/client/src/pages/AddPoemPage/AddPoemPage.tsx
@@ -1,0 +1,61 @@
+import { type ChangeEvent, useState } from "react";
+import "./AddPoemPage.css";
+
+function AddPoemPage() {
+  const [file, setFile] = useState<File | undefined>();
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    e.target.files && setFile(e.target.files[0]);
+  };
+
+  const handleSubmit = (formData: FormData) => {
+    // const values = Object.fromEntries(data);
+
+    fetch("http://localhost:3310/api/poem", {
+      method: "POST",
+      body: JSON.stringify(formData),
+    });
+  };
+  return (
+    <main className="add-poem-page-main">
+      <h1>Ajout de poème</h1>
+      <form action={handleSubmit}>
+        <label htmlFor="title">Titre</label>
+        <input type="text" name="title" placeholder="ex: Demain dès l'aube" />
+        <label htmlFor="description">Texte</label>
+        <textarea
+          name="description"
+          rows={7}
+          placeholder="ex: Demain dès l'aube à l'heure où blanchit la campagne..."
+        />
+        <label htmlFor="image-poem">Image</label>
+        <input
+          type="file"
+          name="image"
+          id="image-poem"
+          accept="png, jpg, jpeg"
+          onChange={handleFile}
+        />
+        <label htmlFor="image-poem" className="file-label">
+          Choisir une image
+        </label>
+
+        {file && (
+          <section>
+            file details:
+            <ul>
+              <li>Name: {file.name}</li>
+              <li>Type: {file.type}</li>
+              <li>Size: {file.size} bytes</li>
+            </ul>
+          </section>
+        )}
+
+        <label htmlFor="date">Date</label>
+        <input type="text" name="date" placeholder="ex: 2024-12-31" />
+        <button type="submit">Ajouter</button>
+      </form>
+    </main>
+  );
+}
+export default AddPoemPage;

--- a/client/src/pages/AddPoemPage/AddPoemPage.tsx
+++ b/client/src/pages/AddPoemPage/AddPoemPage.tsx
@@ -1,61 +1,81 @@
 import { type ChangeEvent, useState } from "react";
 import "./AddPoemPage.css";
+import { ToastContainer, toast } from "react-toastify";
 
 function AddPoemPage() {
   const [file, setFile] = useState<File | undefined>();
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
-    e.target.files && setFile(e.target.files[0]);
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile) {
+      if (selectedFile.size > 500 * 1024) {
+        toast.error("Le fichier ne doit pas dépasser 500 ko");
+        e.target.value = "";
+        setFile(undefined);
+        return;
+      }
+      setFile(selectedFile);
+    }
   };
 
-  const handleSubmit = (formData: FormData) => {
-    // const values = Object.fromEntries(data);
-
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
     fetch("http://localhost:3310/api/poem", {
       method: "POST",
-      body: JSON.stringify(formData),
+      body: formData,
+    }).then((res) => {
+      if (res.ok) {
+        toast.success("Le poème a bien été ajouté.");
+      } else {
+        toast.error("Votre poème n'a pas été ajouté");
+      }
     });
   };
+
   return (
-    <main className="add-poem-page-main">
-      <h1>Ajout de poème</h1>
-      <form action={handleSubmit}>
-        <label htmlFor="title">Titre</label>
-        <input type="text" name="title" placeholder="ex: Demain dès l'aube" />
-        <label htmlFor="description">Texte</label>
-        <textarea
-          name="description"
-          rows={7}
-          placeholder="ex: Demain dès l'aube à l'heure où blanchit la campagne..."
-        />
-        <label htmlFor="image-poem">Image</label>
-        <input
-          type="file"
-          name="image"
-          id="image-poem"
-          accept="png, jpg, jpeg"
-          onChange={handleFile}
-        />
-        <label htmlFor="image-poem" className="file-label">
-          Choisir une image
-        </label>
+    <>
+      <main className="add-poem-page-main">
+        <h1>Ajout de poème</h1>
+        <form onSubmit={handleSubmit}>
+          <label htmlFor="title">Titre</label>
+          <input type="text" name="title" placeholder="ex: Demain dès l'aube" />
+          <label htmlFor="description">Texte</label>
+          <textarea
+            name="description"
+            rows={7}
+            placeholder="ex: Demain dès l'aube à l'heure où blanchit la campagne..."
+          />
+          <label htmlFor="image-poem">Image</label>
+          <input
+            type="file"
+            name="image"
+            id="image-poem"
+            accept="png, jpg, jpeg"
+            onChange={handleFile}
+          />
+          <label htmlFor="image-poem" className="file-label">
+            Choisir une image
+          </label>
 
-        {file && (
-          <section>
-            file details:
-            <ul>
-              <li>Name: {file.name}</li>
-              <li>Type: {file.type}</li>
-              <li>Size: {file.size} bytes</li>
-            </ul>
-          </section>
-        )}
+          {file && (
+            <section>
+              Détails fichier :
+              <ul>
+                <li>Nom: {file.name}</li>
+                <li>Type: {file.type}</li>
+                <li>Taille: {file.size} bytes</li>
+              </ul>
+            </section>
+          )}
 
-        <label htmlFor="date">Date</label>
-        <input type="text" name="date" placeholder="ex: 2024-12-31" />
-        <button type="submit">Ajouter</button>
-      </form>
-    </main>
+          <label htmlFor="date">Date</label>
+          <input type="text" name="date" placeholder="ex: 2024-12-31" />
+          <button type="submit">Ajouter</button>
+        </form>
+      </main>
+      <ToastContainer />
+    </>
   );
 }
 export default AddPoemPage;

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router";
 import App from "./App";
+import AddPoemPage from "./pages/AddPoemPage/AddPoemPage";
 import HomePage from "./pages/HomePage/HomePage";
 import PoemDetailPage from "./pages/PoemDetailPage/PoemDetailPage";
 
@@ -15,6 +16,10 @@ const router = createBrowserRouter([
       {
         element: <PoemDetailPage />,
         path: "poem/:id",
+      },
+      {
+        element: <AddPoemPage />,
+        path: "add-poem",
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.4.1"
+        "react-router": "^7.4.1",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@types/react": "^19.0.12",
@@ -3301,6 +3302,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -7220,6 +7230,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/readable-stream": {


### PR DESCRIPTION
### Summary of Changes

This pull request introduces a new "Add Poem" feature, allowing users to submit poems through a dedicated page. It includes page creation, navigation updates, form validation, styling, and user feedback with toast notifications.

---

### Frontend Changes

#### Add Poem Page

- **Component**: Created `AddPoemPage` (`client/src/pages/AddPoemPage/AddPoemPage.tsx`)
  - Includes form inputs for title, description, image upload, and date.
  - Integrates image file size validation (max 500 KB).
  - Displays success/error messages via `react-toastify`.

- **Styling**: Added responsive styles (`client/src/pages/AddPoemPage/AddPoemPage.css`)
  - Custom styles for layout, form fields, and button interactions.

---

### Dependencies

- **Toast Notifications**: Installed `react-toastify`.  
