### PR TITLE
Us 07 - feat - Link to detail poem 

### DIFF
--- a/client/src/components/PoemCard/PoemCard.tsx
+++ b/client/src/components/PoemCard/PoemCard.tsx
@@ -1,13 +1,12 @@
+import { Link } from "react-router";
 import "./PoemCard.css";
-interface PoemCardProps {
-  title: string;
-  image: string;
-}
-function PoemCard({ title, image }: PoemCardProps) {
+
+function PoemCard({ id, title, image }: PoemCardProps) {
   return (
     <figure className="poem-card-figure">
-      <img src={`http://localhost:3310/${image}`} alt="illustration" />
-
+      <Link to={`poem/${id}`}>
+        <img src={`http://localhost:3310/${image}`} alt="illustration" />
+      </Link>
       <figcaption>
         <span>{title}</span>
         <span>de artiste mystère</span>

--- a/client/src/pages/DisplayPoems/DisplayPoems.tsx
+++ b/client/src/pages/DisplayPoems/DisplayPoems.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
 import PoemCard from "../../components/PoemCard/PoemCard";
 import "./DisplayPoems.css";
 
@@ -21,9 +20,12 @@ function DisplayPoems() {
   return (
     <main className="display-poems-page-main">
       {poems.map((poem) => (
-        <Link to={`/poems/${poem.id}`} key={poem.id}>
-          <PoemCard title={poem.title} image={poem.image} />
-        </Link>
+        <PoemCard
+          key={poem.id}
+          id={poem.id}
+          title={poem.title}
+          image={poem.image}
+        />
       ))}
     </main>
   );

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
 import PoemCard from "../../components/PoemCard/PoemCard";
 import "./HomePage.css";
 
@@ -21,9 +20,12 @@ function HomePage() {
   return (
     <main className="home-page-main">
       {poems.map((poem) => (
-        <Link to="/" key={poem.id}>
-          <PoemCard title={poem.title} image={poem.image} />
-        </Link>
+        <PoemCard
+          key={poem.id}
+          id={poem.id}
+          title={poem.title}
+          image={poem.image}
+        />
       ))}
     </main>
   );

--- a/client/src/types/poem.ts
+++ b/client/src/types/poem.ts
@@ -1,3 +1,9 @@
+interface PoemCardProps {
+  id: number;
+  title: string;
+  image: string;
+}
+
 interface Poem {
   id: number;
   title: string;


### PR DESCRIPTION
This pull request refactors the `PoemCard` component to handle navigation internally and updates its usage across the application. It simplifies the code by removing redundant `Link` wrappers and centralizing the navigation logic within `PoemCard`. 

### Component Refactoring and Navigation Updates:
- Updated `PoemCard` to accept an `id` prop and wrap its image in a `Link` for internal navigation. (`client/src/components/PoemCard/PoemCard.tsx`)
- Removed redundant `Link` wrappers around `PoemCard` in `DisplayPoems` and directly passed the `id` prop to `PoemCard`. (`client/src/pages/DisplayPoems/DisplayPoems.tsx`)
- Similarly, removed `Link` wrappers in `HomePage` and passed the `id` prop to `PoemCard`. (`client/src/pages/HomePage/HomePage.tsx`)

### Cleanup:
- Removed unused `Link` imports from `DisplayPoems` and `HomePage` after refactoring.