### PR TITLE
Chore - 09 - refresh token backend

### DIFF
--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -18,6 +18,7 @@ router.get("/api/items/:id", itemActions.read);
 router.post("/api/items", itemActions.add);
 /* ************************************************************************* */
 router.post("/api/login", auth.login);
+router.get("/api/refresh-token", auth.refreshToken);
 
 /* ************************************************************************* */
 router.get("/api/users", userActions.browse);

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,6 +1,6 @@
 import argon2 from "argon2";
 import type { RequestHandler } from "express";
-import jwt from "jsonwebtoken";
+import jwt, { type JwtPayload } from "jsonwebtoken";
 import userRepository from "../modules/user/userRepository";
 
 const login: RequestHandler = async (req, res, next) => {
@@ -38,4 +38,34 @@ const login: RequestHandler = async (req, res, next) => {
   }
 };
 
-export default { login };
+const refreshToken: RequestHandler = async (req, res, next) => {
+  try {
+    const token = req.cookies.token;
+    if (!token) {
+      res.status(401).json("A token must be provided.");
+      return;
+    }
+    const secretKey = process.env.APP_SECRET;
+    if (!secretKey) {
+      res.status(500).json({ error: "A secret key is needed" });
+      return;
+    }
+
+    const decoded = jwt.verify(token, secretKey);
+    if (decoded) {
+      const payload = decoded as JwtPayload;
+      const newToken = jwt.sign({ id: payload.id }, secretKey, {
+        expiresIn: "1d",
+      });
+      res.cookie("token", newToken, {
+        httpOnly: true,
+        secure: false,
+      });
+      res.status(200).json(payload);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default { login, refreshToken };


### PR DESCRIPTION
## Summary of Changes

This pull request introduces a new `refreshToken` functionality to the authentication system.

---

## Authentication Enhancements

- **New `refreshToken` API endpoint**  
  Added a `GET /api/refresh-token` route in the router to handle token refresh requests.  
  → (`server/src/router.ts`)

- **`refreshToken` handler implementation**  
  Implemented a `refreshToken` handler that:
  - Verifies the current JWT
  - Generates a new token with 1-day expiration
  - Sends it as an HTTP-only cookie  
  Includes appropriate error handling for missing tokens or secret keys.  
  → (`server/src/utils/auth.ts`)