### PR TITLE
Feat - every user can add a poem

### DIFF
--- a/server/src/modules/poem/poemActions.ts
+++ b/server/src/modules/poem/poemActions.ts
@@ -73,8 +73,8 @@ const readPoetPoems: RequestHandler = async (req, res, next) => {
 };
 const add: RequestHandler = async (req, res, next) => {
   try {
-    const { title, description, image, date } = req.body;
-    if (!title || !description || !image || !date) {
+    const { title, description, image, date, user_id } = req.body;
+    if (!title || !description || !image || !date || !user_id) {
       res.status(400).json("Missing required fields");
       return;
     }

--- a/server/src/modules/poem/poemRepository.ts
+++ b/server/src/modules/poem/poemRepository.ts
@@ -76,9 +76,8 @@ class PoemRepository {
       `
         INSERT INTO poem
         (title, description, image, date, user_id)
-        VALUES (?, ?, ?, ?, 1)`,
-      [body.title, body.description, body.image, body.date],
-      // ATTENTION, en dure pour le moment niveau user_id, à voir avec l'amélioration
+        VALUES (?, ?, ?, ?, ?)`,
+      [body.title, body.description, body.image, body.date, body.user_id],
     );
     return result.affectedRows;
   }

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -4,6 +4,7 @@ export type {};
 declare global {
   namespace Express {
     export interface Request {
+      user?: JwtPayload & { id: number; email?: string; name?: string };
       /* ************************************************************************* */
       // Add your custom properties here, for example:
       //


### PR DESCRIPTION
This pull request introduces a change to include a `user_id` field when adding a new poem, ensuring that each poem is associated with a specific user.

### Updates to request validation:

*  Added `user_id` to the list of required fields in the `add` request handler. If `user_id` is missing, the server now returns a `400` status with an appropriate error message.

### Updates to database insertion logic:

* Modified the SQL query to insert the `user_id` field into the `poem` table and updated the parameter list to include `body.user_id`. This replaces the previous hardcoded value for `user_id`.